### PR TITLE
Add wasm32 support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,8 @@ repository = "https://github.com/alecmocatta/build_id"
 homepage = "https://github.com/alecmocatta/build_id"
 documentation = "https://docs.rs/build_id/0.2.1"
 readme = "README.md"
+links = "build_id"
+build = "build.rs"
 edition = "2018"
 
 [badges]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "build_id"
-version = "0.2.0"
+version = "0.2.1"
 license = "MIT OR Apache-2.0"
 authors = ["Alec Mocatta <alec@mocatta.net>"]
 categories = ["development-tools","rust-patterns"]
@@ -10,7 +10,7 @@ Obtain a UUID uniquely representing the build of the current binary.
 """
 repository = "https://github.com/alecmocatta/build_id"
 homepage = "https://github.com/alecmocatta/build_id"
-documentation = "https://docs.rs/build_id/0.2.0"
+documentation = "https://docs.rs/build_id/0.2.1"
 readme = "README.md"
 edition = "2018"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,9 +18,11 @@ edition = "2018"
 azure-devops = { project = "alecmocatta/build_id", pipeline = "tests" }
 maintenance = { status = "passively-maintained" }
 
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+palaver = "0.2"
+
 [dependencies]
 byteorder = "1.2"
 once_cell = "1.2"
-palaver = "0.2"
 twox-hash = { version = "1.1", default-features = false }
 uuid = "0.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,11 +18,14 @@ edition = "2018"
 azure-devops = { project = "alecmocatta/build_id", pipeline = "tests" }
 maintenance = { status = "passively-maintained" }
 
-[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-palaver = "0.2"
-
 [dependencies]
 byteorder = "1.2"
 once_cell = "1.2"
 twox-hash = { version = "1.1", default-features = false }
 uuid = "0.8"
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+palaver = "0.2"
+
+[dev-dependencies]
+wasm-bindgen-test = "0.2"

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 [![MIT / Apache 2.0 licensed](https://img.shields.io/crates/l/build_id.svg?maxAge=2592000)](#License)
 [![Build Status](https://dev.azure.com/alecmocatta/build_id/_apis/build/status/tests?branchName=master)](https://dev.azure.com/alecmocatta/build_id/_build/latest?branchName=master)
 
-[Docs](https://docs.rs/build_id/0.2.0)
+[Docs](https://docs.rs/build_id/0.2.1)
 
-Obtain a [`Uuid`](https://docs.rs/uuid/0.7/uuid/) uniquely representing the
+Obtain a [`Uuid`](https://docs.rs/uuid/0.8/uuid/) uniquely representing the
 build of the current binary.
 
 This is intended to be used to check that different processes are indeed

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -29,4 +29,4 @@ jobs:
         rust_target_run: 'x86_64-apple-darwin i686-apple-darwin'
       linux:
         imageName: 'ubuntu-16.04'
-        rust_target_run: 'x86_64-unknown-linux-gnu i686-unknown-linux-gnu x86_64-unknown-linux-musl i686-unknown-linux-musl'
+        rust_target_run: 'x86_64-unknown-linux-gnu i686-unknown-linux-gnu x86_64-unknown-linux-musl i686-unknown-linux-musl wasm32-unknown-unknown'

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,9 @@
+// See also: https://github.com/rayon-rs/rayon/blob/fc69e50f298b2f5fa2ce9be27827a0850f3bc8f2/rayon-core/build.rs
+//
+// We need a build script to use `links = "build_id"`.  But we're not
+// *actually* linking to anything, just making sure that we're the only
+// build_id in use.
+fn main() {
+	// we don't need to rebuild for anything else
+	println!("cargo:rerun-if-changed=build.rs");
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,7 +95,9 @@ fn from_header<H: Hasher>(_hasher: H) -> Result<H, ()> {
 	Err(())
 }
 #[cfg(target_arch = "wasm32")]
-fn from_exe<H: Hasher>(_hasher: H) -> Result<H, ()> { Err(()) }
+fn from_exe<H: Hasher>(_hasher: H) -> Result<H, ()> {
+	Err(())
+}
 #[cfg(not(target_arch = "wasm32"))]
 fn from_exe<H: Hasher>(mut hasher: H) -> Result<H, ()> {
 	if cfg!(miri) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,6 +94,9 @@ fn from_header<H: Hasher>(_hasher: H) -> Result<H, ()> {
 	// .note.gnu.build-id https://github.com/golang/go/issues/21564 https://github.com/golang/go/blob/178307c3a72a9da3d731fecf354630761d6b246c/src/cmd/go/internal/buildid/buildid.go
 	Err(())
 }
+#[cfg(target_arch = "wasm32")]
+fn from_exe<H: Hasher>(_hasher: H) -> Result<H, ()> { Err(()) }
+#[cfg(not(target_arch = "wasm32"))]
 fn from_exe<H: Hasher>(mut hasher: H) -> Result<H, ()> {
 	if cfg!(miri) {
 		return Err(());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,7 +30,7 @@
 //! `.note.gnu.build-id` on Linux; `LC_UUID` in Mach-O; etc), falling back to
 //! hashing the whole binary.
 
-#![doc(html_root_url = "https://docs.rs/build_id/0.2.0")]
+#![doc(html_root_url = "https://docs.rs/build_id/0.2.1")]
 #![warn(
 	missing_copy_implementations,
 	missing_debug_implementations,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -153,14 +153,19 @@ impl<T: Hasher> io::Write for HashWriter<T> {
 
 #[cfg(test)]
 mod test {
+	use wasm_bindgen_test::wasm_bindgen_test;
+
 	#[test]
+	#[wasm_bindgen_test]
 	fn brute() {
 		let x = super::calculate();
 		for _ in 0..1000 {
 			assert_eq!(x, super::calculate());
 		}
 	}
+
 	#[test]
+	#[wasm_bindgen_test]
 	fn get() {
 		let x = super::calculate();
 		assert_eq!(x, super::get());


### PR DESCRIPTION
Thanks to @j-devel for getting it building under `wasm32`.

I've added the `wasm32` target to CI and bumped the version to push a new release.