### PR TITLE
Drop palaver Dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,8 +26,5 @@ once_cell = "1.2"
 twox-hash = { version = "1.1", default-features = false }
 uuid = "0.8"
 
-[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-palaver = "0.2"
-
 [dev-dependencies]
 wasm-bindgen-test = "0.3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,7 +46,11 @@
 
 use once_cell::sync::Lazy;
 use std::{
-	any::TypeId, hash::{Hash, Hasher}, io
+	any::TypeId,
+	env,
+	fs::File,
+	hash::{Hash, Hasher},
+	io,
 };
 use uuid::Uuid;
 
@@ -100,7 +104,7 @@ fn from_exe<H: Hasher>(mut hasher: H) -> Result<H, ()> {
 		if cfg!(miri) {
 			return Err(());
 		}
-		let file = palaver::env::exe().map_err(drop)?;
+		let file = File::open(env::current_exe().map_err(drop)?).map_err(drop)?;
 		let _ = io::copy(&mut &file, &mut HashWriter(&mut hasher)).map_err(drop)?;
 		Ok(hasher)
 	}


### PR DESCRIPTION
This PR replaces the `palaver` crate with a rust stdlib alternative.
As far as I can tell, it is equivalent, but I did not test it on all supported operating systems.
The reason I did this is that `palaver` fails to build for Android on MacOS, see issue https://github.com/alecmocatta/palaver/issues/49