### PR TITLE
bump uuid dependency to 1.0.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ maintenance = { status = "passively-maintained" }
 byteorder = "1.2"
 once_cell = "1.2"
 twox-hash = { version = "1.1", default-features = false }
-uuid = "0.8"
+uuid = "1.0.0"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 palaver = "0.2"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -136,10 +136,10 @@ fn calculate() -> Uuid {
 	hasher.write_u8(0);
 	<byteorder::NativeEndian as byteorder::ByteOrder>::write_u64(&mut bytes[8..], hasher.finish());
 
-	uuid::Builder::from_bytes(bytes)
+	*uuid::Builder::from_bytes(bytes)
 		.set_variant(uuid::Variant::RFC4122)
 		.set_version(uuid::Version::Random)
-		.build()
+		.as_uuid()
 }
 
 struct HashWriter<T: Hasher>(T);


### PR DESCRIPTION
PR bumps the uuid dependency.

The builder API changed slightly.