### PR TITLE
update & fix CI

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,6 +1,6 @@
 hard_tabs = true
 imports_layout = "Horizontal"
-merge_imports = true
+imports_granularity="Crate"
 fn_args_layout = "Compressed"
 use_field_init_shorthand = true
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,8 +26,5 @@ once_cell = "1.2"
 twox-hash = { version = "1.1", default-features = false }
 uuid = "0.8"
 
-[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-palaver = "0.2"
-
 [dev-dependencies]
 wasm-bindgen-test = "0.3"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,7 +14,7 @@ jobs:
     endpoint: alecmocatta
     default:
       rust_toolchain: nightly
-      rust_lint_toolchain: nightly-2019-10-17
+      rust_lint_toolchain: nightly-2021-07-30
       rust_flags: ''
       rust_features: ''
       rust_target_check: ''

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -26,7 +26,7 @@ jobs:
         rust_target_run: 'x86_64-pc-windows-msvc i686-pc-windows-msvc' # currently broken building crate-type=lib: x86_64-pc-windows-gnu i686-pc-windows-gnu
       mac:
         imageName: 'macos-11'
-        rust_target_run: 'x86_64-apple-darwin i686-apple-darwin'
+        rust_target_run: 'x86_64-apple-darwin'
       linux:
         imageName: 'ubuntu-20.04'
         rust_target_run: 'x86_64-unknown-linux-gnu i686-unknown-linux-gnu x86_64-unknown-linux-musl i686-unknown-linux-musl wasm32-unknown-unknown'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -29,4 +29,4 @@ jobs:
         rust_target_run: 'x86_64-apple-darwin'
       linux:
         imageName: 'ubuntu-20.04'
-        rust_target_run: 'x86_64-unknown-linux-gnu i686-unknown-linux-gnu x86_64-unknown-linux-musl i686-unknown-linux-musl wasm32-unknown-unknown'
+        rust_target_run: 'x86_64-unknown-linux-gnu i686-unknown-linux-gnu x86_64-unknown-linux-musl wasm32-unknown-unknown'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -22,11 +22,11 @@ jobs:
       rust_target_run: ''
     matrix:
       windows:
-        imageName: 'vs2017-win2016'
+        imageName: 'windows-2022'
         rust_target_run: 'x86_64-pc-windows-msvc i686-pc-windows-msvc' # currently broken building crate-type=lib: x86_64-pc-windows-gnu i686-pc-windows-gnu
       mac:
-        imageName: 'macos-10.13'
+        imageName: 'macos-11'
         rust_target_run: 'x86_64-apple-darwin i686-apple-darwin'
       linux:
-        imageName: 'ubuntu-16.04'
+        imageName: 'ubuntu-20.04'
         rust_target_run: 'x86_64-unknown-linux-gnu i686-unknown-linux-gnu x86_64-unknown-linux-musl i686-unknown-linux-musl wasm32-unknown-unknown'

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,7 +110,7 @@ fn from_exe<H: Hasher>(mut hasher: H) -> Result<H, ()> {
 		Err(())
 	}
 }
-fn from_type_id<H: Hasher>(mut hasher: H) -> Result<H, ()> {
+fn from_type_id<H: Hasher>(mut hasher: H) -> H {
 	fn type_id_of<T: 'static>(_: &T) -> TypeId {
 		TypeId::of::<T>()
 	}
@@ -120,7 +120,7 @@ fn from_type_id<H: Hasher>(mut hasher: H) -> Result<H, ()> {
 	type_id_of(&a).hash(&mut hasher);
 	let b = |x: u8| x;
 	type_id_of(&b).hash(&mut hasher);
-	Ok(hasher)
+	hasher
 }
 
 fn calculate() -> Uuid {
@@ -129,7 +129,7 @@ fn calculate() -> Uuid {
 	let hasher = from_header(hasher)
 		.or_else(|()| from_exe(hasher))
 		.unwrap_or(hasher);
-	let mut hasher = from_type_id(hasher).unwrap();
+	let mut hasher = from_type_id(hasher);
 
 	let mut bytes = [0; 16];
 	<byteorder::NativeEndian as byteorder::ByteOrder>::write_u64(&mut bytes[..8], hasher.finish());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,7 +46,7 @@
 
 use once_cell::sync::Lazy;
 use std::{
-	any::TypeId, hash::{Hash, Hasher}, io
+	any::TypeId, env, fs::File, hash::{Hash, Hasher}, io
 };
 use uuid::Uuid;
 
@@ -100,7 +100,7 @@ fn from_exe<H: Hasher>(mut hasher: H) -> Result<H, ()> {
 		if cfg!(miri) {
 			return Err(());
 		}
-		let file = palaver::env::exe().map_err(drop)?;
+		let file = File::open(env::current_exe().map_err(drop)?).map_err(drop)?;
 		let _ = io::copy(&mut &file, &mut HashWriter(&mut hasher)).map_err(drop)?;
 		Ok(hasher)
 	}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,9 +18,9 @@
 //! # let remote_build_id = build_id::get();
 //! let local_build_id = build_id::get();
 //! if local_build_id == remote_build_id {
-//! 	println!("We're running the same binary as remote!");
+//!     println!("We're running the same binary as remote!");
 //! } else {
-//! 	println!("We're running a different binary to remote");
+//!     println!("We're running a different binary to remote");
 //! }
 //! ```
 //!
@@ -72,9 +72,9 @@ static BUILD_ID: Lazy<Uuid> = Lazy::new(calculate);
 /// # let remote_build_id = build_id::get();
 /// let local_build_id = build_id::get();
 /// if local_build_id == remote_build_id {
-/// 	println!("We're running the same binary as remote!");
+///     println!("We're running the same binary as remote!");
 /// } else {
-/// 	println!("We're running a different binary to remote");
+///     println!("We're running a different binary to remote");
 /// }
 /// ```
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,7 +46,7 @@
 
 use once_cell::sync::Lazy;
 use std::{
-	any::TypeId, env, fs::File, hash::{Hash, Hasher}, io
+	any::TypeId, hash::{Hash, Hasher}, io
 };
 use uuid::Uuid;
 
@@ -97,6 +97,7 @@ fn from_header<H: Hasher>(_hasher: H) -> Result<H, ()> {
 fn from_exe<H: Hasher>(mut hasher: H) -> Result<H, ()> {
 	#[cfg(not(target_arch = "wasm32"))]
 	{
+		use std::{env, fs::File};
 		if cfg!(miri) {
 			return Err(());
 		}


### PR DESCRIPTION
This PR does some changes to get CI passing again:

- update azure images
 
'vs2017-win2016' -> 'windows-2022'
'macos-10.13' -> 'macos-11'
'ubuntu-16.04' -> 'ubuntu-20.04'

According to [Microsoft](https://docs.microsoft.com/en-us/azure/devops/pipelines/agents/hosted?view=azure-devops), the windows image is deprecated and will be removed in June. The macos and ubuntu have already been removed.

- bump lint toolchain to nightly-2021-07-30 (needed to not stumble over bumpalo's `[doc = include_str!(...)]`
- drop i686-apple-darwin builds (rustup doesn't provide built toolchains anymore)
- drop i686-unknown-linux-musl (somehow CI cannot build it)
- replace tabs with spaces in doc comments (newer clippy [doesn't like those](https://rust-lang.github.io/rust-clippy/master/index.html#tabs_in_doc_comments)
- include domenukk's commit which drops the palaver dependency
  @alecmocatta I'm aware that is also your crate, but it's quite heavy a dependency and not that maintained. It also contains an outdated and insecure heapless.
- `from_type_id()` now doesn't need to return a `Result`, and clippy complains, so drop that
